### PR TITLE
eliot -> V1.0

### DIFF
--- a/Assets/Prefabs/Enemy/ArcherSkeleton LP.prefab
+++ b/Assets/Prefabs/Enemy/ArcherSkeleton LP.prefab
@@ -360,9 +360,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moneyGain: 100
   speed: 10
-  startHealth: 100
-  meetSpeed: 10
+  startHealth: 70
   healthBar: {fileID: 186503435067288760}
+  defense: 0
 --- !u!1 &1904029173652300192
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemy/Golem.prefab
+++ b/Assets/Prefabs/Enemy/Golem.prefab
@@ -207,11 +207,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ec2b8a876a05e468db30e9fb406a2e11, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  tower: {fileID: 115737610557479704, guid: e137ee75867bfc1419f89d0745e67a0e, type: 3}
   moneyGain: 100
   speed: 50
   startHealth: 300
   healthBar: {fileID: 8624955402536995847}
+  defense: 0
 --- !u!1 &8528263202085179086
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemy/GruntHP.prefab
+++ b/Assets/Prefabs/Enemy/GruntHP.prefab
@@ -900,9 +900,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moneyGain: 100
   speed: 10
-  startHealth: 100
-  meetSpeed: 10
+  startHealth: 50
   healthBar: {fileID: 733658875619388123}
+  defense: 0
 --- !u!1 &6861734824079427252
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemy/MageSkeleton LP.prefab
+++ b/Assets/Prefabs/Enemy/MageSkeleton LP.prefab
@@ -1018,9 +1018,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moneyGain: 100
   speed: 10
-  startHealth: 1000
-  meetSpeed: 10
+  startHealth: 1500
   healthBar: {fileID: 2359404805405151222}
+  defense: 0
 --- !u!1 &5175631825890931858
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemy/Toon Crystal Keeper Red.prefab
+++ b/Assets/Prefabs/Enemy/Toon Crystal Keeper Red.prefab
@@ -5387,9 +5387,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moneyGain: 100
   speed: 10
-  startHealth: 1000
-  meetSpeed: 10
+  startHealth: 2500
   healthBar: {fileID: 7307389740920219631}
+  defense: 0
 --- !u!1 &1612892249347116202
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemy/Toon Queen Worm - Pink.prefab
+++ b/Assets/Prefabs/Enemy/Toon Queen Worm - Pink.prefab
@@ -816,9 +816,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moneyGain: 100
   speed: 10
-  startHealth: 1000
-  meetSpeed: 10
+  startHealth: 2000
   healthBar: {fileID: 5872978771394639269}
+  defense: 0
 --- !u!1 &2206742854500198535
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemy/Toon Rock Golem-Red.prefab
+++ b/Assets/Prefabs/Enemy/Toon Rock Golem-Red.prefab
@@ -5323,9 +5323,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moneyGain: 100
   speed: 10
-  startHealth: 100
-  meetSpeed: 10
+  startHealth: 110
   healthBar: {fileID: 8084741943621997576}
+  defense: 0
 --- !u!1 &6661587253496327042
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemy/Toon Worm - Pink.prefab
+++ b/Assets/Prefabs/Enemy/Toon Worm - Pink.prefab
@@ -6089,9 +6089,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moneyGain: 100
   speed: 10
-  startHealth: 100
-  meetSpeed: 10
+  startHealth: 90
   healthBar: {fileID: 2188689250162156802}
+  defense: 0
 --- !u!1 &6928798303330495663
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Skill Effects/1001.prefab
+++ b/Assets/Resources/Skill Effects/1001.prefab
@@ -14011,7 +14011,7 @@ Transform:
   m_GameObject: {fileID: 1727626132299242}
   m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0.01, z: 0}
-  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_LocalScale: {x: 10, y: 10, z: 5}
   m_Children:
   - {fileID: 4851461471953128}
   - {fileID: 4227749349955704}

--- a/Assets/Scenes/TempScene_test.unity
+++ b/Assets/Scenes/TempScene_test.unity
@@ -2372,7 +2372,7 @@ GameObject:
   m_Layer: 5
   m_Name: MenuScene
   m_TagString: Untagged
-  m_Icon: {fileID: 0}
+  m_Icon: {fileID: -5397416234189338067, guid: 0000000000000000d000000000000000, type: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
@@ -2586,7 +2586,7 @@ GameObject:
   m_Layer: 0
   m_Name: WayPoint (1)
   m_TagString: Untagged
-  m_Icon: {fileID: -5397416234189338067, guid: 0000000000000000d000000000000000, type: 0}
+  m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
@@ -2894,7 +2894,7 @@ GameObject:
   m_Layer: 0
   m_Name: BackGround
   m_TagString: Untagged
-  m_Icon: {fileID: 0}
+  m_Icon: {fileID: -5397416234189338067, guid: 0000000000000000d000000000000000, type: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1

--- a/Assets/Scenes/TempScene_test.unity
+++ b/Assets/Scenes/TempScene_test.unity
@@ -1139,6 +1139,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 12800000, guid: 4beb055f07aaff244873dec698d0363e,
         type: 3}
+    - target: {fileID: 1518290669548581096, guid: f705fed9a9d5cf7408540435d88bdbfc,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 426.73047
+      objectReference: {fileID: 0}
     - target: {fileID: 1518290669624667608, guid: f705fed9a9d5cf7408540435d88bdbfc,
         type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -1157,7 +1162,7 @@ PrefabInstance:
     - target: {fileID: 1518290670025897083, guid: f705fed9a9d5cf7408540435d88bdbfc,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -176.49951
+      value: -176.49902
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f705fed9a9d5cf7408540435d88bdbfc, type: 3}
@@ -1576,6 +1581,7 @@ GameObject:
   m_Component:
   - component: {fileID: 525015167}
   - component: {fileID: 525015166}
+  - component: {fileID: 525015168}
   - component: {fileID: 525015165}
   - component: {fileID: 525015164}
   m_Layer: 0
@@ -1598,7 +1604,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   startMoney: 99999
-  startLives: 40
+  startLives: 20
 --- !u!114 &525015165
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1656,6 +1662,37 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &525015168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 525015163}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7918dbe790c64e06a361ade73a1e833, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyPrefab1: {fileID: 4455827164297312159, guid: 8bb464bb7e3db4307bf9b08647b3d3d1,
+    type: 3}
+  enemyPrefab1Boss: {fileID: 6254600380530622362, guid: 51f5cd544c64647c6b558dab65c7a36c,
+    type: 3}
+  enemyPrefab2: {fileID: 2879778464649646526, guid: 604644d40e3f74f88abcf7a1018ad1d8,
+    type: 3}
+  enemyPrefab2Boss: {fileID: 638780595971567119, guid: 6049ca38f58e14bf48759e6c74bb451c,
+    type: 3}
+  enemyPrefab3: {fileID: 6928798303329984395, guid: 044e57f9464e046199d1cc6f03d348cd,
+    type: 3}
+  enemyPrefab3Boss: {fileID: 2206742854499899757, guid: c041f24328b094bb08e2dcad73ebc71c,
+    type: 3}
+  enemyPrefab4: {fileID: 6661587253496617862, guid: 88bcbd26906464cd0a6ec102bf8b0b7a,
+    type: 3}
+  enemyPrefab4Boss: {fileID: 1612892249347341142, guid: 02c587e9f1b9246db9f92213d60bb1da,
+    type: 3}
+  spawnPoint: {fileID: 5321908}
+  RoundCountText: {fileID: 358052289}
+  waveCountdownText: {fileID: 358052288}
 --- !u!1001 &525393996
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3568,7 +3605,7 @@ Light:
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: NaN, y: NaN, z: NaN, w: NaN}
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 6.593e-42, w: 1.04e-43}
   m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0

--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -10,7 +10,7 @@ public class Bullet : MonoBehaviour
     public float speed = 70f;
     public GameObject impactEffect;
     private GameObject skill_effect;
-    public int damage = 50;
+    public float damage = 50;
 
     void Start()
     {
@@ -45,8 +45,13 @@ public class Bullet : MonoBehaviour
     {
         if(Skill1007)
         {
-            GameObject _skill_effect = (GameObject)Instantiate(skill_effect, transform.position, transform.rotation);
+            GameObject _skill_effect = (GameObject)Instantiate(skill_effect, transform.position + new Vector3(0,4,0), transform.rotation);
+            damage *= 2f;
             
+        }
+        else
+        {
+            damage *= 0.5f;
         }
         GameObject effectIns = (GameObject)Instantiate(impactEffect, transform.position, transform.rotation);
         Destroy(effectIns, 2f);

--- a/Assets/Scripts/DataBaseManager.cs
+++ b/Assets/Scripts/DataBaseManager.cs
@@ -34,13 +34,13 @@ public class DataBaseManager : MonoBehaviour
         skillList_Hyper.Add(new Skill(2007, "얼음 초월", "각성 얼음 초월입니다", Skill.Skill_Type.Hyper));
         skillList_Hyper.Add(new Skill(2008, "사형선고", "각성 사형선고입니다", Skill.Skill_Type.Hyper));
 
-        skillEffects.Add(new SkillEffect(1000, 0, 20, 20));
-        skillEffects.Add(new SkillEffect(1001, 3, 20, 20));
-        skillEffects.Add(new SkillEffect(1002, 0, 20, 20));
-        skillEffects.Add(new SkillEffect(1003, 0, 20, 20));
+        skillEffects.Add(new SkillEffect(1000, 3, 20, 20));
+        skillEffects.Add(new SkillEffect(1001, 6, 50, 20));
+        skillEffects.Add(new SkillEffect(1002, 3, 20, 20));
+        skillEffects.Add(new SkillEffect(1003, 3, 20, 20));
         skillEffects.Add(new SkillEffect(1004, 3, 20, 20));
         skillEffects.Add(new SkillEffect(1005, 3, 20, 20));
         skillEffects.Add(new SkillEffect(1006, 3, 20, 20));
-        skillEffects.Add(new SkillEffect(1007, 3, 20, 100));
+        skillEffects.Add(new SkillEffect(1007, 0, 20, 100));
     }
 }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -8,7 +8,7 @@ public class Enemy : MonoBehaviour
     public int moneyGain = 100;
     public float speed = 10f;
 
-    public int startHealth = 100;
+    public float startHealth = 100;
 
     public float meetSpeed = 10f;
 
@@ -71,13 +71,13 @@ public class Enemy : MonoBehaviour
         //transform.Rotate(0, -13.846153f, 0);
     }
 
-    public void TakeDamage(int amount)
+    public void TakeDamage(float amount)
     {
         health -= amount;
 
         healthBar.fillAmount = health / startHealth;
 
-        if(health <= 0)
+        if(health <= 0f)
         {
             Die();
         }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -10,13 +10,14 @@ public class Enemy : MonoBehaviour
 
     public float startHealth = 100;
 
-    public float meetSpeed = 10f;
+    private float meetSpeed = 10f;
 
     private Transform target;
     private float health;
 
     public Image healthBar;
     private int waypointCount = 0;
+    public float defense = 0f;
 
     void Start()
     {
@@ -62,6 +63,7 @@ public class Enemy : MonoBehaviour
             waypointCount = 1;
             target = Waypoints.points[waypointCount];
             waypointCount++;
+            defense++;
         }
         else
         {
@@ -73,7 +75,10 @@ public class Enemy : MonoBehaviour
 
     public void TakeDamage(float amount)
     {
-        health -= amount;
+        //health -= amount;
+
+        // 피해량 = 데미지(amount) + 100 / (100+방어력)
+        health -= amount * 100 / (100 + defense);
 
         healthBar.fillAmount = health / startHealth;
 

--- a/Assets/Scripts/PlayerStats.cs
+++ b/Assets/Scripts/PlayerStats.cs
@@ -6,8 +6,8 @@ public class PlayerStats : MonoBehaviour
     public static int Money;
     public int startMoney;
 
-    public static int Lives;
-    public int startLives;
+    public static float Lives;
+    public float startLives;
 
     void Start()
     {

--- a/Assets/Scripts/Skills/DamageWithSkill.cs
+++ b/Assets/Scripts/Skills/DamageWithSkill.cs
@@ -5,50 +5,47 @@ using UnityEngine;
 public class DamageWithSkill : MonoBehaviour
 {
     private static float explosionRadius;
-    private static int damage;
+    private static float damage;
 
 
     public static void ActivateSkill(SkillEffect _skill_effect, GameObject _enemy)
     {
-        if(_skill_effect.Skill_ID != 1007)
-        {
-            GameObject ImpactEffect = (GameObject)Instantiate(_skill_effect.Skill_Effect, _enemy.transform.position, Quaternion.Euler(-70, 0, 0));
-            Destroy(ImpactEffect, 2f);
-        }
         explosionRadius = _skill_effect.Radius;
         damage = _skill_effect.Damage;
 
-        if(explosionRadius > 0f)
+        if (explosionRadius > 0f)
         {
-            Explode(_enemy.transform);
-            _skill_effect.ExtraSkillEffects();
+            GameObject ImpactEffect = (GameObject)Instantiate(_skill_effect.Skill_Effect, _enemy.transform.position, Quaternion.Euler(-70, 0, 0));
+            Destroy(ImpactEffect, 2f);
+
+            Explode(_enemy.transform, _skill_effect);
         }
-        else
-        {
-            _skill_effect.ExtraSkillEffects();
-            Damage(_enemy.transform);
-        }
+        //else
+        //{
+        //    _skill_effect.ExtraSkillEffects();
+        //    Damage(_enemy.transform);
+        //}
     }
 
-    static void Explode(Transform enemy)
+    static void Explode(Transform enemy, SkillEffect _skill_effect)
     {
         Collider[] colliders = Physics.OverlapSphere(enemy.position, explosionRadius);
         foreach(Collider collider in colliders)
         {
             if(collider.tag == "Enemy")
             {
-                Damage(collider.transform);
+                Damage(collider.transform, _skill_effect);
             }
         }
     }
 
-    static void Damage(Transform enemy)
+    static void Damage(Transform enemy, SkillEffect _skill_effect)
     {
         Enemy e = enemy.GetComponent<Enemy>();
 
         if(e != null)
         {
-            e.TakeDamage(damage);
+            _skill_effect.ExtraSkillEffects(e, damage);
         }
     }
     

--- a/Assets/Scripts/Skills/SkillEffect.cs
+++ b/Assets/Scripts/Skills/SkillEffect.cs
@@ -8,19 +8,21 @@ public class SkillEffect
     public int Skill_Prob;                  // 스킬 발동확률
     public int Skill_ID;                    // 스킬 아이디
     public float Radius;                    // 스킬 범위
-    public int Damage;                      // 스킬 데미지
+    public float Damage;                      // 스킬 데미지
     public GameObject Skill_Effect;         // 스킬 이펙트
     public Sprite Skill_Image;              // 스킬 이미지
 
-    public void ExtraSkillEffects()         // 추가 스킬 효과
+    public void ExtraSkillEffects(Enemy e, float _damage)         // 추가 스킬 효과
     {
         switch (this.Skill_ID)
         {
             case 1000:
-                // 전체체력 퍼뎀
+                _damage = e.startHealth * 0.2f;
+                e.TakeDamage(_damage);              // 전체체력 퍼뎀
                 // 방깍
                 break;
             case 1001:
+                e.TakeDamage(_damage);
                 // 큰 범위
                 break;
             case 1002:
@@ -50,7 +52,7 @@ public class SkillEffect
 
 
     }
-    public SkillEffect(int _skill_ID, float _Radius, int _Damage, int _Skill_Prob)
+    public SkillEffect(int _skill_ID, float _Radius, float _Damage, int _Skill_Prob)
     {
         this.Skill_ID = _skill_ID;
         this.Radius = _Radius;
@@ -58,7 +60,8 @@ public class SkillEffect
         this.Skill_Prob = _Skill_Prob;
         this.Skill_Image = Resources.Load("Skills/" + _skill_ID.ToString(), typeof(Sprite)) as Sprite;
         this.Skill_Effect = Resources.Load("Skill Effects/" + _skill_ID,typeof(GameObject)) as GameObject;
-        
+        //this.Skill_Effect = Resources.Load("Skill Effects/1001", typeof(GameObject)) as GameObject;
+
     }
     void OnDrawGizmosSelected()
     {

--- a/Assets/Scripts/WaveSpawner.cs
+++ b/Assets/Scripts/WaveSpawner.cs
@@ -66,7 +66,6 @@ public class WaveSpawner : MonoBehaviour
             default:
                 break;
         }
-
         for (int i = 0; i < waveIndex; i++)
         {
             SpawnEnemy();

--- a/Assets/Scripts/WaveSpawner_test.cs
+++ b/Assets/Scripts/WaveSpawner_test.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 using UnityEngine.UI;
 
-public class WaveSpawner : MonoBehaviour
+public class WaveSpawner_test : MonoBehaviour
 {
     
     public Transform enemyPrefab1;
@@ -19,11 +19,11 @@ public class WaveSpawner : MonoBehaviour
     //public Transform[] enemyPrefab = { enemy1, enemy2 };
     public Transform spawnPoint;
 
-    private float timeBetweenWaves = 40f; // 1f
-    private float countdown = 10f; // 40f Prepare Skill before Game Start
+    private float timeBetweenWaves = 1f; // 20f
+    private float countdown = 3f; // 40f Prepare Skill before Game Start
     
     private int waveNumber = 0;
-    private int waveIndex = 20; //2
+    private int waveIndex = 2; //20
 
     public Text RoundCountText;
     public Text waveCountdownText;

--- a/Assets/Scripts/WaveSpawner_test.cs.meta
+++ b/Assets/Scripts/WaveSpawner_test.cs.meta
@@ -1,0 +1,20 @@
+fileFormatVersion: 2
+guid: d7918dbe790c64e06a361ade73a1e833
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - enemyPrefab1: {fileID: 1213788161931097311, guid: 2ee9fec876cd0484d98b63f9b0e29305,
+      type: 3}
+  - enemyPrefab1Boss: {fileID: 6254600380530622362, guid: 51f5cd544c64647c6b558dab65c7a36c,
+      type: 3}
+  - enemyPrefab2: {fileID: 9135923744139380246, guid: e06a56237b96149cd9c01deb07fa032a,
+      type: 3}
+  - spawnPoint: {instanceID: 0}
+  - RoundCountText: {instanceID: 0}
+  - waveCountdownText: {instanceID: 0}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
add Enemy Defense
  - 1 lap increases Enemy defense++

modify Enemy Life
  - int to float
  - If Life is less than Enemy Count, Life Count will print a negative quantity
  - use LifeUI.cs and PlayerStats.cs

add WaveSpawner_test.cs
  - This file can test all enemy types

mdy WaveSpawner.cs
  - This file is just what we drawing conclusions
  - 게임 시작 전 시간 : 10초
  - 다음 웨이브까지의 남은 시간 : 40초
  - 몬스터 소환 횟수 : 20마리
  - 만약 정식 버전인 WaveSpawner.cs가 아닌 1초마다 2마리씩 나오는 WavepSpawner_test.cs를 사용하고 싶다면 GameMaster 오브젝트에서 Inspector 화면에 보이는 WaveSpawner.cs 컴포넌트의 체크를 해제하고 WaveSpawner_test.cs 컴포넌트를 체크 요망

mdy Enemy health
  - grunt : 50
  - orc_wolf_rider : 1000
  - skeleton_archer : 70
  - skeleton_mager : 1500
  - worm : 90
  - worm Queen : 2000
  - golem : 110
  - inferno : 2500